### PR TITLE
save memory avoiding const declarations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,11 @@ async function checkAvailableProducts(): Promise<void> {
       const isAvailable = !product.text().includes("Sin stock");
 
       if (isAvailable) {
-        const title = product.find(".item-link").first().attr("title")!;
-        const price = product.find(".item-price").first().text().trim();
-        const link = product.find(".item-link").first().attr("href")!;
-        const availableProduct = new Product(title, price, link);
+        const availableProduct = new Product(
+          product.find(".item-link").first().attr("title")!,
+          product.find(".item-price").first().text().trim(),
+          product.find(".item-link").first().attr("href")!,
+        );
 
         availableProducts.push(availableProduct);
       }


### PR DESCRIPTION
La declaración de `const` `title`, `price` y `link` consume recursos que podemos ahorrar asignando directamente los valores deseados en el `constructor` de la `class` `Product`.